### PR TITLE
Fix login timeout cleanup

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -77,32 +77,38 @@ const Login = () => {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const timerRef = useRef(null);
+  const timeoutRef = useRef(null);
+  const isMounted = useRef(true);
 
   useEffect(() => {
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
+      isMounted.current = false;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
     };
   }, []);
+
+  const startRedirect = (path) => {
+    const id = setTimeout(() => {
+      if (isMounted.current) {
+        setLoading(false);
+        navigate(path);
+      }
+    }, 2000);
+    timeoutRef.current = id;
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (username === "admin" && password === "admin") {
       setError("");
       setLoading(true);
-      timerRef.current = setTimeout(() => {
-        setLoading(false);
-        navigate("/dashboard");
-      }, 2000);
+      startRedirect("/dashboard");
     } else if (username === "bruno" && password === "bruno$2025") {
       setError("");
       setLoading(true);
-      timerRef.current = setTimeout(() => {
-        setLoading(false);
-        navigate("/home");
-      }, 2000);
+      startRedirect("/home");
     } else {
       setError("Usuário ou senha inválidos");
     }


### PR DESCRIPTION
## Summary
- store `setTimeout` id in a ref
- clear timeout on unmount
- ensure no state updates occur after navigating away

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684028f04550832abc885ac623ddbd6f