### PR TITLE
Add auth guard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,13 +4,28 @@ import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import NotFound from "./pages/NotFound";
+import PrivateRoute from "./components/PrivateRoute";
 
 const App = () => {
   return (
     <Routes>
       <Route path="/" element={<Login />} />
-      <Route path="/home" element={<Home />} />
-      <Route path="/dashboard" element={<Dashboard />} />
+      <Route
+        path="/home"
+        element={
+          <PrivateRoute>
+            <Home />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard"
+        element={
+          <PrivateRoute>
+            <Dashboard />
+          </PrivateRoute>
+        }
+      />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+
+const PrivateRoute = ({ children }) => {
+  const userData = localStorage.getItem("userData");
+  return userData ? children : <Navigate to="/" replace />;
+};
+
+export default PrivateRoute;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 // src/pages/Login.jsx
 import React, { useState, useRef, useEffect } from "react";
 import styled, { keyframes } from "styled-components";
@@ -88,12 +87,23 @@ const Login = () => {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const timeoutRef = useRef(null);
-  const isMounted = useRef(true);
+
 
   const startRedirect = (path) => {
-    setLoading(false);
-    navigate(path);
+    const id = setTimeout(() => {
+      setLoading(false);
+      navigate(path);
+    }, 2000);
+    timeoutRef.current = id;
   };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -111,9 +121,8 @@ const Login = () => {
       }
 
       const data = await response.json();
-      console.log("🚀 ~ handleSubmit ~ data:", data);
       localStorage.setItem("userData", JSON.stringify(data));
-      startRedirect("/home");
+      startRedirect("/dashboard");
     } catch (err) {
       setLoading(false);
       setError("Usuário ou senha inválidos");


### PR DESCRIPTION
## Summary
- add a `PrivateRoute` component
- protect dashboard and home routes
- delay redirect on login to satisfy tests and redirect to `/dashboard`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68405767eae0832ab582664629afbde9