### PR TITLE
Implement user registration page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
+import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import NotFound from "./pages/NotFound";
 import PrivateRoute from "./components/PrivateRoute";
@@ -10,6 +11,7 @@ const App = () => {
   return (
     <Routes>
       <Route path="/" element={<Login />} />
+      <Route path="/register" element={<Register />} />
       <Route
         path="/home"
         element={

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -17,7 +17,7 @@ jest.mock('react-router-dom', () => {
 describe('Login page', () => {
   beforeEach(() => {
     mockNavigate.mockReset();
-    global.fetch = jest.fn();
+    globalThis.fetch = jest.fn();
     localStorage.clear();
   });
 
@@ -32,7 +32,7 @@ describe('Login page', () => {
         <Login />
       </MemoryRouter>
     );
-    global.fetch.mockResolvedValue({ ok: false });
+    globalThis.fetch.mockResolvedValue({ ok: false });
     await user.type(
       screen.getByPlaceholderText(/digite seu email/i),
       'foo@test.com'
@@ -45,7 +45,7 @@ describe('Login page', () => {
   test('navigates to dashboard on valid admin login', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    global.fetch.mockResolvedValue({
+    globalThis.fetch.mockResolvedValue({
       ok: true,
       json: async () => ({ slug: 's', nome: 'n', token: 't' }),
     });
@@ -66,5 +66,17 @@ describe('Login page', () => {
       JSON.stringify({ slug: 's', nome: 'n', token: 't' })
     );
     jest.useRealTimers();
+  });
+
+  test('shows link to register', () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /cadastre-se/i })).toHaveAttribute(
+      'href',
+      '/register'
+    );
   });
 });

--- a/src/__tests__/Register.test.jsx
+++ b/src/__tests__/Register.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Register from '../pages/Register';
+import { act } from 'react-dom/test-utils';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('Register page', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('shows validation error when passwords mismatch', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText(/digite seu nome/i), 'Foo');
+    await user.type(screen.getByPlaceholderText(/digite seu email/i), 'foo@test.com');
+    await user.type(screen.getByPlaceholderText(/digite sua senha/i), '123456');
+    await user.type(screen.getByPlaceholderText(/confirme sua senha/i), '654321');
+    await user.click(screen.getByRole('button', { name: /cadastrar/i }));
+    expect(screen.getByText(/senhas não conferem/i)).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test('submits form and redirects on success', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    globalThis.fetch.mockResolvedValue({ ok: true });
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText(/digite seu nome/i), 'Foo');
+    await user.type(screen.getByPlaceholderText(/digite seu email/i), 'foo@test.com');
+    await user.type(screen.getByPlaceholderText(/digite sua senha/i), '123456');
+    await user.type(screen.getByPlaceholderText(/confirme sua senha/i), '123456');
+    await user.click(screen.getByRole('button', { name: /cadastrar/i }));
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://code-race-qfh4.onrender.com/usuario',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+    jest.useRealTimers();
+  });
+});

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,10 +1,9 @@
-// src/pages/Login.jsx
 import React, { useState, useRef, useEffect } from "react";
 import styled, { keyframes } from "styled-components";
 import Input from "../components/Input";
 import Button from "../components/Button";
 import Card from "../components/Card";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const Container = styled.div`
   display: flex;
@@ -80,21 +79,16 @@ const Spinner = styled.div`
   animation: ${spin} 1s linear infinite;
 `;
 
-const RegisterLink = styled(Link)`
-  color: #4f46e5;
-  text-align: center;
-  margin-top: 1rem;
-  text-decoration: underline;
-`;
-
-const Login = () => {
+const Register = () => {
   const navigate = useNavigate();
+  const [nome, setNome] = useState("");
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+  const [senha, setSenha] = useState("");
+  const [confirmarSenha, setConfirmarSenha] = useState("");
+  const [errors, setErrors] = useState({});
+  const [submitError, setSubmitError] = useState("");
   const [loading, setLoading] = useState(false);
   const timeoutRef = useRef(null);
-
 
   const startRedirect = (path) => {
     const id = setTimeout(() => {
@@ -112,27 +106,39 @@ const Login = () => {
     };
   }, []);
 
+  const validate = () => {
+    const newErrors = {};
+    if (!nome.trim()) newErrors.nome = "Nome obrigat\u00f3rio";
+    if (!email.trim()) newErrors.email = "Email obrigat\u00f3rio";
+    else if (!/\S+@\S+\.\S+/.test(email)) newErrors.email = "Email inv\u00e1lido";
+    if (senha.length < 6) newErrors.senha = "Senha deve ter 6 caracteres";
+    if (senha !== confirmarSenha)
+      newErrors.confirmarSenha = "As senhas n\u00e3o conferem";
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError("");
+    setSubmitError("");
+    if (!validate()) return;
     setLoading(true);
     try {
-      const response = await fetch("https://code-race-qfh4.onrender.com/auth", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, senha: password }),
-      });
-
+      const response = await fetch(
+        "https://code-race-qfh4.onrender.com/usuario",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ nome, email, senha }),
+        }
+      );
       if (!response.ok) {
-        throw new Error("Login failed");
+        throw new Error("Erro ao cadastrar");
       }
-
-      const data = await response.json();
-      localStorage.setItem("userData", JSON.stringify(data));
-      startRedirect("/dashboard");
+      startRedirect("/");
     } catch {
       setLoading(false);
-      setError("Usuário ou senha inválidos");
+      setSubmitError("Erro ao cadastrar usu\u00e1rio");
     }
   };
 
@@ -145,27 +151,43 @@ const Login = () => {
       )}
       <StyledCard>
         <Logo src="/image/gato.webp" alt="Logo do Projeto" />
-        <Form onSubmit={handleSubmit}>
+        <Form onSubmit={handleSubmit} noValidate>
+          <Input
+            label="Nome"
+            placeholder="Digite seu nome"
+            value={nome}
+            onChange={(e) => setNome(e.target.value)}
+            error={errors.nome}
+          />
           <Input
             label="Email"
             placeholder="Digite seu email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            error={errors.email}
           />
           <Input
             label="Senha"
             placeholder="Digite sua senha"
             type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            value={senha}
+            onChange={(e) => setSenha(e.target.value)}
+            error={errors.senha}
           />
-          <Button type="submit">Entrar</Button>
-          <RegisterLink to="/register">Cadastre-se</RegisterLink>
-          {error && <ErrorMessage>{error}</ErrorMessage>}
+          <Input
+            label="Confirmar Senha"
+            placeholder="Confirme sua senha"
+            type="password"
+            value={confirmarSenha}
+            onChange={(e) => setConfirmarSenha(e.target.value)}
+            error={errors.confirmarSenha}
+          />
+          <Button type="submit">Cadastrar</Button>
+          {submitError && <ErrorMessage>{submitError}</ErrorMessage>}
         </Form>
       </StyledCard>
     </Container>
   );
 };
 
-export default Login;
+export default Register;


### PR DESCRIPTION
## Summary
- create Register page with form validation and API integration
- add route for `/register`
- link login page to sign up form
- test registration flow and login link

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406f0b1f74832a89a8b304a76a00fc