### PR TITLE
Add user type select to register form

### DIFF
--- a/src/__tests__/Register.test.jsx
+++ b/src/__tests__/Register.test.jsx
@@ -31,6 +31,7 @@ describe('Register page', () => {
         <Register />
       </MemoryRouter>
     );
+    await user.selectOptions(screen.getByRole('combobox'), 'professor');
     await user.type(screen.getByPlaceholderText(/digite seu nome/i), 'Foo');
     await user.type(screen.getByPlaceholderText(/digite seu email/i), 'foo@test.com');
     await user.type(screen.getByPlaceholderText(/digite sua senha/i), '123456');
@@ -49,6 +50,7 @@ describe('Register page', () => {
         <Register />
       </MemoryRouter>
     );
+    await user.selectOptions(screen.getByRole('combobox'), 'professor');
     await user.type(screen.getByPlaceholderText(/digite seu nome/i), 'Foo');
     await user.type(screen.getByPlaceholderText(/digite seu email/i), 'foo@test.com');
     await user.type(screen.getByPlaceholderText(/digite sua senha/i), '123456');

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+const Label = styled.label`
+  font-size: 0.875rem;
+  color: #374151;
+`;
+
+const StyledSelect = styled.select`
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  width: 100%;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #4f46e5;
+    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.3);
+  }
+`;
+
+const Error = styled.span`
+  color: #b91c1c;
+  font-size: 0.75rem;
+`;
+
+const Select = ({ label, error, children, ...props }) => {
+  return (
+    <Wrapper>
+      {label && <Label>{label}</Label>}
+      <StyledSelect {...props}>{children}</StyledSelect>
+      {error && <Error>{error}</Error>}
+    </Wrapper>
+  );
+};
+
+export default Select;

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import styled, { keyframes } from "styled-components";
 import Input from "../components/Input";
+import Select from "../components/Select";
 import Button from "../components/Button";
 import Card from "../components/Card";
 import { useNavigate } from "react-router-dom";
@@ -99,6 +100,7 @@ const Register = () => {
   const [email, setEmail] = useState("");
   const [senha, setSenha] = useState("");
   const [confirmarSenha, setConfirmarSenha] = useState("");
+  const [tipo, setTipo] = useState("aluno");
   const [errors, setErrors] = useState({});
   const [submitError, setSubmitError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -144,7 +146,7 @@ const Register = () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ nome, email, senha }),
+          body: JSON.stringify({ nome, email, senha, tipo }),
         }
       );
       if (!response.ok) {
@@ -198,6 +200,14 @@ const Register = () => {
             onChange={(e) => setConfirmarSenha(e.target.value)}
             error={errors.confirmarSenha}
           />
+          <Select
+            label="Tipo de usu\u00e1rio"
+            value={tipo}
+            onChange={(e) => setTipo(e.target.value)}
+          >
+            <option value="professor">Professor</option>
+            <option value="aluno">Aluno</option>
+          </Select>
           <Button type="submit">Cadastrar</Button>
           {submitError && <ErrorMessage>{submitError}</ErrorMessage>}
         </Form>


### PR DESCRIPTION
## Summary
- create `Select` component for dropdown inputs
- add `tipo` state and select field in `Register` page
- send `tipo` to backend on registration
- update registration tests for new select field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbefc6400832a88a5b8bcc21c3f40