### PR TITLE
Update user type field

### DIFF
--- a/src/__tests__/Register.test.jsx
+++ b/src/__tests__/Register.test.jsx
@@ -31,7 +31,7 @@ describe('Register page', () => {
         <Register />
       </MemoryRouter>
     );
-    await user.selectOptions(screen.getByRole('combobox'), 'professor');
+    await user.selectOptions(screen.getByRole('combobox'), '1');
     await user.type(screen.getByPlaceholderText(/digite seu nome/i), 'Foo');
     await user.type(screen.getByPlaceholderText(/digite seu email/i), 'foo@test.com');
     await user.type(screen.getByPlaceholderText(/digite sua senha/i), '123456');
@@ -50,7 +50,7 @@ describe('Register page', () => {
         <Register />
       </MemoryRouter>
     );
-    await user.selectOptions(screen.getByRole('combobox'), 'professor');
+    await user.selectOptions(screen.getByRole('combobox'), '1');
     await user.type(screen.getByPlaceholderText(/digite seu nome/i), 'Foo');
     await user.type(screen.getByPlaceholderText(/digite seu email/i), 'foo@test.com');
     await user.type(screen.getByPlaceholderText(/digite sua senha/i), '123456');

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -100,7 +100,8 @@ const Register = () => {
   const [email, setEmail] = useState("");
   const [senha, setSenha] = useState("");
   const [confirmarSenha, setConfirmarSenha] = useState("");
-  const [tipo, setTipo] = useState("aluno");
+  // 0 representa Aluno e 1 representa Professor
+  const [tipoUsuario, setTipoUsuario] = useState(0);
   const [errors, setErrors] = useState({});
   const [submitError, setSubmitError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -146,7 +147,7 @@ const Register = () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ nome, email, senha, tipo }),
+          body: JSON.stringify({ nome, email, senha, tipoUsuario }),
         }
       );
       if (!response.ok) {
@@ -202,11 +203,11 @@ const Register = () => {
           />
           <Select
             label="Tipo de usu\u00e1rio"
-            value={tipo}
-            onChange={(e) => setTipo(e.target.value)}
+            value={tipoUsuario}
+            onChange={(e) => setTipoUsuario(parseInt(e.target.value, 10))}
           >
-            <option value="professor">Professor</option>
-            <option value="aluno">Aluno</option>
+            <option value={1}>Professor</option>
+            <option value={0}>Aluno</option>
           </Select>
           <Button type="submit">Cadastrar</Button>
           {submitError && <ErrorMessage>{submitError}</ErrorMessage>}


### PR DESCRIPTION
## Summary
- register page: send numeric `tipoUsuario` values instead of string type
- adjust tests to select the new numeric value

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cc07d3e50832ab071ec23d9614332