### PR TITLE
Handle teacher/student redirects on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este projeto é uma aplicação React construída com Vite. Ele contém um formu
 
 ## Exemplo de credenciais de login
 
-Qualquer usuário válido registrado no backend pode ser utilizado. Quando a autenticação é bem-sucedida, o `slug`, `nome` e `token` retornados são salvos no `localStorage` na chave `userData` e o usuário é redirecionado para o dashboard.
+Qualquer usuário válido registrado no backend pode ser utilizado. Quando a autenticação é bem-sucedida, o `slug`, `nome`, `token` e `tipoUsuario` retornados são salvos no `localStorage` na chave `userData`. Se o usuário for professor (`tipoUsuario` igual a `1`), ele é redirecionado para o dashboard; caso contrário, é levado para a página inicial com informações sobre os formulários disponíveis.
 
 ## Rodando localmente
 

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -42,12 +42,12 @@ describe('Login page', () => {
     expect(screen.getByText(/usuário ou senha inválidos/i)).toBeInTheDocument();
   });
 
-  test('navigates to dashboard on valid admin login', async () => {
+  test('navigates to dashboard on valid teacher login', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     globalThis.fetch.mockResolvedValue({
       ok: true,
-      json: async () => ({ slug: 's', nome: 'n', token: 't' }),
+      json: async () => ({ slug: 's', nome: 'n', token: 't', tipoUsuario: 1 }),
     });
     render(
       <MemoryRouter>
@@ -63,7 +63,33 @@ describe('Login page', () => {
     });
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
     expect(localStorage.getItem('userData')).toBe(
-      JSON.stringify({ slug: 's', nome: 'n', token: 't' })
+      JSON.stringify({ slug: 's', nome: 'n', token: 't', tipoUsuario: 1 })
+    );
+    jest.useRealTimers();
+  });
+
+  test('navigates to home on valid student login', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ slug: 's', nome: 'n', token: 't', tipoUsuario: 0 }),
+    });
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText(/digite seu email/i), 'aluno@test.com');
+    await user.type(screen.getByPlaceholderText(/digite sua senha/i), 'aluno');
+    await user.click(screen.getByRole('button', { name: /entrar/i }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+    expect(localStorage.getItem('userData')).toBe(
+      JSON.stringify({ slug: 's', nome: 'n', token: 't', tipoUsuario: 0 })
     );
     jest.useRealTimers();
   });

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,9 +5,19 @@ import LogoutButton from "../components/LogoutButton";
 const Home = () => {
   return (
     <div style={{ padding: "2rem" }}>
-      <h1>Home</h1>
-      <Button>Exemplo de botão</Button>
-      <LogoutButton />
+      <h1>Bem-vindo ao CodeRace</h1>
+      <p>
+        Nesta página você encontrará informações sobre o projeto e poderá
+        acessar os formulários disponíveis para preenchimento.
+      </p>
+      <ul>
+        <li>Formulário de exemplo 1</li>
+        <li>Formulário de exemplo 2</li>
+      </ul>
+      <Button>Acessar Formulários</Button>
+      <div style={{ marginTop: "1rem" }}>
+        <LogoutButton />
+      </div>
     </div>
   );
 };

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -147,7 +147,8 @@ const Login = () => {
 
       const data = await response.json();
       localStorage.setItem("userData", JSON.stringify(data));
-      startRedirect("/dashboard");
+      const redirectPath = data.tipoUsuario === 1 ? "/dashboard" : "/home";
+      startRedirect(redirectPath);
     } catch {
       setLoading(false);
       setError("Usuário ou senha inválidos");


### PR DESCRIPTION
## Summary
- show landing page text after login
- redirect to dashboard for teachers and to home for students
- document new behavior
- test role-based redirects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc4861438832a8b704adf472f4ded