### PR TITLE
Add LogicForm page and routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
+import LogicForm from "./pages/LogicForm";
 import NotFound from "./pages/NotFound";
 import PrivateRoute from "./components/PrivateRoute";
 
@@ -25,6 +26,14 @@ const App = () => {
         element={
           <PrivateRoute>
             <Dashboard />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/forms/logic"
+        element={
+          <PrivateRoute>
+            <LogicForm />
           </PrivateRoute>
         }
       />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import Button from "../components/Button";
 import LogoutButton from "../components/LogoutButton";
+import { useNavigate } from "react-router-dom";
 
 const Home = () => {
+  const navigate = useNavigate();
+
   return (
     <div style={{ padding: "2rem" }}>
       <h1>Bem-vindo ao CodeRace</h1>
@@ -10,11 +13,19 @@ const Home = () => {
         Nesta página você encontrará informações sobre o projeto e poderá
         acessar os formulários disponíveis para preenchimento.
       </p>
-      <ul>
-        <li>Formulário de exemplo 1</li>
-        <li>Formulário de exemplo 2</li>
+      <ul style={{ listStyle: "none", padding: 0, marginBottom: "1rem" }}>
+        <li style={{ marginBottom: "0.5rem" }}>
+          <Button onClick={() => navigate("/forms/logic")}>
+            Formulário de Lógica
+          </Button>
+        </li>
+        <li style={{ marginBottom: "0.5rem" }}>
+          <Button disabled>Formulário de Matemática</Button>
+        </li>
+        <li>
+          <Button disabled>Formulário de Português</Button>
+        </li>
       </ul>
-      <Button>Acessar Formulários</Button>
       <div style={{ marginTop: "1rem" }}>
         <LogoutButton />
       </div>

--- a/src/pages/LogicForm.jsx
+++ b/src/pages/LogicForm.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import LogoutButton from "../components/LogoutButton";
+
+const LogicForm = () => {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Formul\u00e1rio de L\u00f3gica</h1>
+      <p>Este formul\u00e1rio vir\u00e1 de uma rota do backend.</p>
+      <LogoutButton />
+    </div>
+  );
+};
+
+export default LogicForm;


### PR DESCRIPTION
## Summary
- create LogicForm page placeholder
- add `/forms/logic` route
- link form options on home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc7807fd0832aa2477ece2d7b3e5d