### PR TITLE
Update fonts and unify form layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
       rel="stylesheet"
     />
     <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
       href="https://fonts.googleapis.com/css2?family=Edu+TAS+Beginner&display=swap"
       rel="stylesheet"
     />

--- a/src/components/FormLayout.jsx
+++ b/src/components/FormLayout.jsx
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+import Card from "./Card";
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  padding: 1rem;
+  font-family: "Inter", sans-serif;
+  transition: background 0.5s ease;
+`;
+
+export const StyledCard = styled(Card)`
+  padding: 4rem;
+  border-radius: 20px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.15);
+  width: 100%;
+  max-width: 1000px;
+  min-height: 500px;
+  background-color: #ffffffee;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  }
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const Logo = styled.img`
+  width: 100px;
+  height: auto;
+  display: block;
+  margin: 0 auto 1.5rem auto;
+`;
+
+const FormLayout = ({ children }) => {
+  return (
+    <Container>
+      <StyledCard>{children}</StyledCard>
+    </Container>
+  );
+};
+
+export default FormLayout;

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   background-color: #f4f4f4;
   color: #333;
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 const Container = styled.div`
   padding: 2rem;
   min-height: 100vh;
-  font-family: "Edu TAS Beginner", cursive;
+  font-family: "Inter", sans-serif;
   background: "#fff";
   color: #000;
 `;
@@ -23,6 +23,7 @@ const Banner = styled.div`
 
 const Title = styled.h1`
   font-size: 2.5rem;
+  font-family: "Edu TAS Beginner", cursive;
   margin: 0;
 `;
 

--- a/src/pages/LogicForm.jsx
+++ b/src/pages/LogicForm.jsx
@@ -1,13 +1,21 @@
 import React from "react";
 import LogoutButton from "../components/LogoutButton";
+import FormLayout, { Form, Logo } from "../components/FormLayout";
+import Button from "../components/Button";
 
 const LogicForm = () => {
   return (
-    <div style={{ padding: "2rem" }}>
-      <h1>Formul\u00e1rio de L\u00f3gica</h1>
-      <p>Este formul\u00e1rio vir\u00e1 de uma rota do backend.</p>
-      <LogoutButton />
-    </div>
+    <FormLayout>
+      <Logo src="/image/gato.webp" alt="Logo do Projeto" />
+      <h1 style={{ fontFamily: "'Edu TAS Beginner', cursive" }}>
+        Formulário de Lógica
+      </h1>
+      <Form>
+        <p>Este formulário virá de uma rota do backend.</p>
+        <Button disabled>Enviar</Button>
+        <LogoutButton />
+      </Form>
+    </FormLayout>
   );
 };
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,49 +3,9 @@ import React, { useState, useRef, useEffect } from "react";
 import styled, { keyframes } from "styled-components";
 import Input from "../components/Input";
 import Button from "../components/Button";
-import Card from "../components/Card";
+import FormLayout, { Form, Logo } from "../components/FormLayout";
 import Toast from "../components/Toast";
 import { useNavigate, Link, useLocation } from "react-router-dom";
-
-const Container = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  background: linear-gradient(135deg, #6366f1, #4f46e5);
-  padding: 1rem;
-  font-family: "Roboto", sans-serif;
-  transition: background 0.5s ease;
-`;
-
-const Logo = styled.img`
-  width: 100px;
-  height: auto;
-  display: block;
-  margin: 0 auto 1.5rem auto;
-`;
-
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-`;
-
-const StyledCard = styled(Card)`
-  padding: 4rem;
-  border-radius: 20px;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.15);
-  width: 100%;
-  max-width: 1000px;
-  min-height: 500px;
-  background-color: #ffffffee;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
-
-  &:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
-  }
-`;
 
 const ErrorMessage = styled.p`
   color: red;
@@ -156,7 +116,7 @@ const Login = () => {
   };
 
   return (
-    <Container>
+    <FormLayout>
       {showSuccess && (
         <Toast message="Cadastro realizado com sucesso!" type="success" />
       )}
@@ -165,8 +125,7 @@ const Login = () => {
           <Spinner />
         </LoadingOverlay>
       )}
-      <StyledCard>
-        <Logo src="/image/gato.webp" alt="Logo do Projeto" />
+      <Logo src="/image/gato.webp" alt="Logo do Projeto" />
         <Form onSubmit={handleSubmit}>
           <Input
             label="Email"
@@ -185,8 +144,7 @@ const Login = () => {
           <RegisterLink to="/register">Cadastre-se</RegisterLink>
           {error && <ErrorMessage>{error}</ErrorMessage>}
         </Form>
-      </StyledCard>
-    </Container>
+    </FormLayout>
   );
 };
 

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -3,48 +3,8 @@ import styled, { keyframes } from "styled-components";
 import Input from "../components/Input";
 import Select from "../components/Select";
 import Button from "../components/Button";
-import Card from "../components/Card";
+import FormLayout, { Form, Logo } from "../components/FormLayout";
 import { useNavigate } from "react-router-dom";
-
-const Container = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  background: linear-gradient(135deg, #6366f1, #4f46e5);
-  padding: 1rem;
-  font-family: "Roboto", sans-serif;
-  transition: background 0.5s ease;
-`;
-
-const Logo = styled.img`
-  width: 100px;
-  height: auto;
-  display: block;
-  margin: 0 auto 1.5rem auto;
-`;
-
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-`;
-
-const StyledCard = styled(Card)`
-  padding: 4rem;
-  border-radius: 20px;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.15);
-  width: 100%;
-  max-width: 1000px;
-  min-height: 500px;
-  background-color: #ffffffee;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
-
-  &:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
-  }
-`;
 
 const ErrorMessage = styled.p`
   color: red;
@@ -85,7 +45,7 @@ const HeaderTitle = styled.h1`
   text-align: center;
   font-size: 2rem;
   margin-bottom: 1.5rem;
-  font-family: "Roboto", sans-serif;
+  font-family: "Edu TAS Beginner", cursive;
   font-weight: 500;
   transition: color 0.3s ease;
   cursor: pointer;
@@ -161,14 +121,13 @@ const Register = () => {
   };
 
   return (
-    <Container>
+    <FormLayout>
       {loading && (
         <LoadingOverlay>
           <Spinner />
         </LoadingOverlay>
       )}
-      <StyledCard>
-        <Logo src="/image/gato.webp" alt="Logo do Projeto" />
+      <Logo src="/image/gato.webp" alt="Logo do Projeto" />
         <HeaderTitle>Cadastro</HeaderTitle>
         <Form onSubmit={handleSubmit} noValidate>
           <Input
@@ -212,8 +171,7 @@ const Register = () => {
           <Button type="submit">Cadastrar</Button>
           {submitError && <ErrorMessage>{submitError}</ErrorMessage>}
         </Form>
-      </StyledCard>
-    </Container>
+    </FormLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- switch body font to Inter and load font from Google
- create reusable `FormLayout` component
- apply new layout to Login, Register and Logic forms
- keep titles with Edu TAS font

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd0380ba0832a8a4c3b495624b0c5