### PR TITLE
Add double diagonal banner component

### DIFF
--- a/src/components/DoubleDiagonalBanner.jsx
+++ b/src/components/DoubleDiagonalBanner.jsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+const StyledBanner = styled.div`
+  background: linear-gradient(135deg, #4f46e5, #6b5ce7, #8b5cf6);
+  color: #fff;
+  padding: 4rem 2rem;
+  text-align: center;
+  clip-path: polygon(0 10%, 100% 0, 100% 90%, 0 100%);
+  margin: -2rem -2rem 2rem;
+`;
+
+const DoubleDiagonalBanner = ({ children, ...props }) => {
+  return <StyledBanner {...props}>{children}</StyledBanner>;
+};
+
+export default DoubleDiagonalBanner;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import Button from "../components/Button";
 import LogoutButton from "../components/LogoutButton";
+import DoubleDiagonalBanner from "../components/DoubleDiagonalBanner";
 import { useNavigate } from "react-router-dom";
 
 const Container = styled.div`
@@ -81,9 +82,9 @@ const Home = () => {
         <IntroImage src="/image/imagem_home.jpg" alt="Imagem inicial" />
       </Intro>
       <div style={{ marginTop: "5rem" }}>
-        <Banner>
+        <DoubleDiagonalBanner>
           <Title>Formulários</Title>
-        </Banner>
+        </DoubleDiagonalBanner>
       </div>
       <ul style={{ listStyle: "none", padding: 0, marginBottom: "1rem" }}>
         <li style={{ marginBottom: "0.5rem" }}>


### PR DESCRIPTION
## Summary
- add `DoubleDiagonalBanner` component so banners can have top and bottom angles
- use the new component for the 'Formulários' banner on the Home page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cd8afb138832abc07f29525bc78d7